### PR TITLE
Add Sum?

### DIFF
--- a/aggregator/aggregator.html
+++ b/aggregator/aggregator.html
@@ -29,6 +29,7 @@
             <option value="median">Median value</option>
             <option value="min">Minimum value</option>
             <option value="max">Maximum value</option>
+            <option value="sum">Sum value</option>
         </select>
     </div>
     <div class="form-row inject-time-row" id="inject-time-row-interval">

--- a/aggregator/aggregator.js
+++ b/aggregator/aggregator.js
@@ -56,6 +56,10 @@ module.exports = function (RED) {
                 case "max":
                     output = simpleStatistics.max(list);
                     break;
+                    
+                    case "sum":
+                    output = simpleStatistics.sumSimple(list);
+                    break;
             }
 
             return output;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Roger Jaggi",
   "license": "Apache-2.0",
   "dependencies": {
-    "simple-statistics": "^1.0.1"
+    "simple-statistics": "^2.0"
   },
   "node-red": {
     "nodes": {


### PR DESCRIPTION
Hi, I attempted to add a SUM function (sumSimple) which is available in simpleStastics, but it appears to crash the server every time it runs.  If I set it to take the sum every 2 minutes, I get a "Lost connection to the server" about every 2 minutes and no output from the node.   Previously it was very stable. 

Any thoughts on what I did wrong? 

I have a rain Gauge (tipping bucket) and an ESP8266 sends the count of tips every minute, and I am trying to get hourly and daily totals to calculate hourly and daily rainfall.  

Thanks

Update:
After checking the log, it appears sumSimple is not in simpleStatistics 1.0.1, after changing to 2.0 (I think it installed 2.0.1) it seems to work correctly, at least for "sumSimple".  
