### PR TITLE
Submit the aggregated value per topic

### DIFF
--- a/aggregator/aggregator.html
+++ b/aggregator/aggregator.html
@@ -16,6 +16,15 @@
         icon: "arrow-in.png",
         label: function() {
             return this.name||"aggregator";
+        },
+        oneditprepare: function () {
+            $("#node-input-submitPerTopic").change(function () {
+                if ($(this).is(":checked")) {
+                    $(".node-input-topic-row").hide();
+                } else {
+                    $(".node-input-topic-row").show();
+                }
+            });
         }
     });
 </script>
@@ -51,7 +60,7 @@
         <label style="width: auto" for="node-input-submitPerTopic">Submit one message per topic</label>
         <input style="width: 50px" type="checkbox" id="node-input-submitPerTopic"></input>
     </div>
-    <div class="form-row">
+    <div class="form-row node-input-topic-row">
         <label for="node-input-topic"><i class="fa fa-tasks"></i> Topic</label>
         <input type="text" id="node-input-topic" style="width: 70%x"></input>
     </div>

--- a/aggregator/aggregator.html
+++ b/aggregator/aggregator.html
@@ -78,6 +78,8 @@
             <li>Aggregation of all retrieved values per topic by the defined aggregation method</li>
             <li>(optional) Aggregation of the aggregated results per topic by the defined aggregation method one more time</li>
         </ol>
+        If <i>Submit one message per topic</i> is selected, the second aggregration step will be skipped.
+        One individual message is sent for each topic along with the original topic name.
     </p>
     <p>Topic and error handling:<br />
         <ol>

--- a/aggregator/aggregator.html
+++ b/aggregator/aggregator.html
@@ -8,6 +8,7 @@
             "intervalCount": {value: 1, required: true, validate: RED.validators.number()},
             "intervalUnits": {value: "h", required: true },
             submitIncompleteInterval: {value: true },
+            submitPerTopic: {value: false },
             aggregationType: {value: "mean"}
         },
         inputs:1,
@@ -47,6 +48,10 @@
         <input style="width: 50px" type="checkbox" id="node-input-submitIncompleteInterval"></input>
     </div>
     <div class="form-row">
+        <label style="width: auto" for="node-input-submitPerTopic">Submit one message per topic</label>
+        <input style="width: 50px" type="checkbox" id="node-input-submitPerTopic"></input>
+    </div>
+    <div class="form-row">
         <label for="node-input-topic"><i class="fa fa-tasks"></i> Topic</label>
         <input type="text" id="node-input-topic" style="width: 70%x"></input>
     </div>
@@ -62,7 +67,7 @@
     regardless of how many values are retrieved per topic. Once the time span times out, this leads to the following calculation of all retrieved values:
         <ol>
             <li>Aggregation of all retrieved values per topic by the defined aggregation method</li>
-            <li>Aggregation of the aggregated results per topic by the defined aggregation method one more time</li>
+            <li>(optional) Aggregation of the aggregated results per topic by the defined aggregation method one more time</li>
         </ol>
     </p>
     <p>Topic and error handling:<br />

--- a/aggregator/aggregator.js
+++ b/aggregator/aggregator.js
@@ -66,19 +66,30 @@ module.exports = function (RED) {
         };
 
         node.aggregateAll = function () {
-            var results = [];
-
-            for (var topic in node.values) {
-                if (node.values.hasOwnProperty(topic) && node.values[topic].length > 0) {
-                    results.push(node.aggregate(node.values[topic]));
+            if (config.submitPerTopic) {
+                for (var topic in node.values) {
+                    if (node.values.hasOwnProperty(topic) && node.values[topic].length > 0) {
+                        node.send({
+                            topic: topic,
+                            payload: node.aggregate(node.values[topic])
+                        });
+                    }
                 }
-            }
+            } else {
+                var results = [];
 
-            if (results.length > 0) {
-                node.send({
-                    topic: config.topic,
-                    payload: node.aggregate(results)
-                });
+                for (var topic in node.values) {
+                    if (node.values.hasOwnProperty(topic) && node.values[topic].length > 0) {
+                        results.push(node.aggregate(node.values[topic]));
+                    }
+                }
+
+                if (results.length > 0) {
+                    node.send({
+                        topic: config.topic,
+                        payload: node.aggregate(results)
+                    });
+                }
             }
 
             node.values = {};


### PR DESCRIPTION
Hi,

my use-case is to aggregate values originating from different topics over a time period using a single aggregator node, but emit the _value per topic independently_ (much like the 'trigger' or 'delay' core nodes).

This node does exactly what I was looking for, except that it performs a second aggregation over all topics and then just sends a single message under a new topic name configured in the node.

So I added an option that allows you to skip the second aggregation step and send the aggregated topic value for each topic separately instead. Each topic is treated independently and will use the original topic name, the topic property set in the node will be ignored in this case.

It is disabled by default to keep the current behavior.

Feel free to comment or use this pull request.

Regards!