### PR TITLE
Update aggregator.js

### DIFF
--- a/aggregator/aggregator.js
+++ b/aggregator/aggregator.js
@@ -7,7 +7,10 @@ module.exports = function (RED) {
         var node = this;
         node.intervalCount = config["interval-count"];
         node.intervalUnits = config["interval-units"];
-        node.absoluteStartupTime = new Date().getTime();
+        node.absoluteStartupTime = new Date();
+        node.absoluteStartupTime.setMinutes(node.absoluteStartupTime.getMinutes() - node.absoluteStartupTime.getTimezoneOffset());
+        node.correctedStartupTime = node.absoluteStartupTime.getTime();
+
         node.factor = 1;
 
         switch (config.intervalUnits) {

--- a/aggregator/aggregator.js
+++ b/aggregator/aggregator.js
@@ -29,7 +29,7 @@ module.exports = function (RED) {
         }
 
         node.intervalTimeout = node.factor * config.intervalCount;
-        node.startupTimeout = node.intervalTimeout - (node.absoluteStartupTime % node.intervalTimeout);
+        node.startupTimeout = node.intervalTimeout - (node.correctedStartupTime % node.intervalTimeout);
         node.values = {};
 
         node.aggregate = function (list) {


### PR DESCRIPTION
Added support for different timezones than UTC so that the daily factor runs at 0:00 local server time.
As a bonus the hourly also now runs on the proper time.

For example every 8 hours would run at 9:00, 17:00 and at 1:00 CET without the timezone correction.
With this correction it runs at 8:00, 16:00 and 24:00 CET